### PR TITLE
refactor(code): remove unused line from flannel loadout entry

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/clothing.dm
+++ b/code/modules/client/preference_setup/loadout/lists/clothing.dm
@@ -6,7 +6,6 @@
 /datum/gear/clothing/flannel
 	display_name = "flannel (colorable)"
 	path = /obj/item/clothing/accessory/toggleable/flannel
-	slot = slot_tie
 	flags = GEAR_HAS_COLOR_SELECTION
 
 /datum/gear/clothing/scarf


### PR DESCRIPTION
Overriding the valid slot for flannels is redundant as base type already specifies the same slot.