### PR TITLE
feat(code): remove unused turf proc

### DIFF
--- a/code/_helpers/turfs.dm
+++ b/code/_helpers/turfs.dm
@@ -12,13 +12,6 @@
 /proc/isfloor(turf/T)
 	return (istype(T, /turf/simulated/floor) || istype(T, /turf/unsimulated/floor))
 
-// TODO(rufus): remove, unused proc
-/proc/turf_clear(turf/T)
-	for(var/atom/A in T)
-		if(A.simulated)
-			return FALSE
-	return TRUE
-
 // Picks a turf without a mob from the given list of turfs, if one exists.
 // If no such turf exists, picks any random turf from the given list of turfs.
 /proc/pick_mobless_turf_if_exists(list/start_turfs)


### PR DESCRIPTION
Unused proc, added 10 years ago, which was supposed to clear turfs of the type specified in the code. 
Earlier it was used in https://github.com/ZeroHubProjects/ZeroOnyx/commit/24adb8eb42ae842ffed50bc262c8068dacb5fdca , where it was used in two places to replace the '!F.contents.len' checks.
It is not used in any way nowadays, and seems to have been replaced by another proc's, much more efficient (?) than this one.
If you ever need it for anything, you can bring it back. For now, it's better to remove it.