### PR TITLE
fix(code): nuclear gun not using correct in-hand icon

### DIFF
--- a/code/modules/projectiles/guns/energy/energy.dm
+++ b/code/modules/projectiles/guns/energy/energy.dm
@@ -82,6 +82,7 @@
 	then click where you want to fire. Laser mode can fire through windows harmlessly. To switch between stun and lethal, click the weapon \
 	in your hand. Unlike most energy weapons, this weapon recharges on its own."
 	icon_state = "nucgun"
+	item_state = null	//so the human update icon uses the icon_state instead.
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 5, TECH_POWER = 3)
 	slot_flags = SLOT_BELT
 	w_class = ITEM_SIZE_LARGE


### PR DESCRIPTION
Advanced energy gun already has its own sprite for item_state, but due to a bug (?) in the code it doesn't use it. I fixed it.

So here's what it looks like in the game:

![nuclear_gun_item_state](https://github.com/user-attachments/assets/ecdb8c70-22a8-4c31-9c30-cbfcdd0fe184)
